### PR TITLE
fix windows specific errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Setup:
 
 Things to do:
 
-- Open devtools with `Ctrl+Shift+I` or `Cmd+Option+I`
+- Open devtools with `Ctrl+Alt+I` or `Cmd+Option+I`
 - Access the Taut settings tab in Preferences to see installed plugins and
   config info
 - Use plugins by setting `"enabled": true` in `config.jsonc` and saving the file

--- a/cli/helpers.js
+++ b/cli/helpers.js
@@ -257,7 +257,7 @@ export async function findSlackInstall() {
  */
 export async function checkWriteAccess(dir) {
   try {
-    await fs.access(dir, constants.W_OK)
+    await fs.access(path.join(dir, 'app.asar'), constants.W_OK)
     return true
   } catch {
     return false

--- a/core/main/deps.ts
+++ b/core/main/deps.ts
@@ -103,7 +103,7 @@ export async function bundle(
           build.onLoad(
             { filter: /.*/, namespace: 'local-fs' },
             async (args) => {
-              if (useGlobalTautPlugin && args.path.endsWith('core/Plugin.ts')) {
+              if (useGlobalTautPlugin && path.basename(args.path) === 'Plugin.ts') {
                 return {
                   contents: `
                     export const TautPlugin = globalThis.TautPlugin

--- a/core/preload/preload.js
+++ b/core/preload/preload.js
@@ -211,7 +211,7 @@ const rendererCodePromise = ipcRenderer.invoke('taut:get-renderer-code')
   const head = parsedDocument.head
   const rendererCode = await rendererCodePromise
   const scriptEl = parsedDocument.createElement('script')
-  scriptEl.textContent = `// Taut injected renderer code\nBuilt from core/renderer/main.ts\n${rendererCode}`
+  scriptEl.textContent = `// Taut injected renderer code\n// Built from core/renderer/main.ts\n${rendererCode}`
   head.insertBefore(scriptEl, head.firstChild)
 
   const html = parsedDocument.documentElement.outerHTML


### PR DESCRIPTION
[fix: check](https://github.com/jeremy46231/taut/commit/56ffceabcafb5d533f0292d43950439a6f0b2a78) (in deps.ts) uses a hardcoded forward-slash, while Windows uses backslashes -- replaced with path to work on all OSes

[fix: change checkWriteAccess()](https://github.com/jeremy46231/taut/commit/c46c6f41a3da51effe5f72e74a3299de69948f47) to check write access to the asar itself, instead of the directory, which fixes EPERM errors on windows (because windows is weird and gives access to the dir but not the specific file)