### PR TITLE
Enable `scrollBounce`

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -77,6 +77,7 @@ function openOptionsWindow() {
     webPreferences: {
       preload: optionsPreload,
       contextIsolation: true,
+      scrollBounce: true
     },
   })
   win.loadFile(optionsHtml)

--- a/desktop/src/patch.ts
+++ b/desktop/src/patch.ts
@@ -133,6 +133,7 @@ export function applyPatches(slackAsarPath: string, tautPreloadPath: string) {
           ...opts.webPreferences,
           preload: tautPreloadPath,
           devTools: true,
+          scrollBounce: true
         },
       })
     },


### PR DESCRIPTION
Fun overscroll effect on macOS!

https://github.com/user-attachments/assets/d1f73732-c5cc-4189-9dfd-9f984fa8220a

Applied in the patched Slack window and in the options window.

It's a pretty minimal change, but tested and it doesn't break everything.