### PR TITLE
Add Orpheus haiku warning plugin

### DIFF
--- a/plugins/HaikuWarning.tsx
+++ b/plugins/HaikuWarning.tsx
@@ -1,0 +1,161 @@
+// Warns before sending a haiku that Orpheus will copy into the thread
+
+import { type Delta, TautPlugin } from '$taut'
+import { blocksToSlackText, dictionaryLookup, findHaiku } from './lib/haiku'
+
+type SendOptions = { delta: Delta }
+type ComposerProps = {
+  channelId?: string
+  conversationId?: string
+  channel?: { id?: string }
+  prepareAndSendMessage?: (options: SendOptions) => unknown
+}
+
+const EXCLUDED_CHANNEL = 'C09MATKQM8C'
+const DICTIONARY_KEY = 'orpheus-syllables-aece7f5'
+const DICTIONARY_URL =
+  'https://raw.githubusercontent.com/hackclub/orpheus-bot/aece7f5fcc873b8e71ecccfa5216849fafd959e1/app/lib/haiku_check/syllable_counts.txt'
+
+export default class HaikuWarning extends TautPlugin {
+  static readonly id = 'HaikuWarning'
+  static readonly pluginName = 'Haiku Warning'
+  static readonly description =
+    'Warns before sending a haiku that Orpheus may copy into the thread'
+  static readonly authors = '<@U09KKMHLS15>'
+  static readonly defaultConfig = `
+    // Warn before Orpheus copies an accidental haiku into the thread
+    "HaikuWarning": {
+      "enabled": false
+    }
+  `
+
+  private dictionary: Promise<string | null> | undefined
+  private readonly approved = new WeakSet<Delta>()
+  private readonly pending = new WeakMap<Delta, Promise<boolean>>()
+
+  start(): void {
+    this.dictionary = this.loadDictionary()
+
+    for (const name of ['MessagePaneInput', 'InputContainer'] as const) {
+      this.api.patchComponent<ComposerProps>(name, (Original) => (props) => {
+        const originalSend = props.prepareAndSendMessage
+        const channelId =
+          props.channelId ?? props.conversationId ?? props.channel?.id
+        const send = React.useCallback(
+          (options: SendOptions) =>
+            this.reviewAndSend(options, channelId, originalSend),
+          [channelId, originalSend]
+        )
+
+        if (!originalSend) return <Original {...props} />
+        return <Original {...props} prepareAndSendMessage={send} />
+      })
+    }
+
+    this.log('Started')
+  }
+
+  private async reviewAndSend(
+    options: SendOptions,
+    channelId: string | undefined,
+    send: ComposerProps['prepareAndSendMessage']
+  ): Promise<unknown> {
+    if (!send) return
+
+    const delta = options.delta
+    if (this.approved.delete(delta) || channelId === EXCLUDED_CHANNEL) {
+      return send(options)
+    }
+
+    const existing = this.pending.get(delta)
+    if (existing) {
+      // One click owns the eventual send; repeated shortcuts while its modal is
+      // open should not queue duplicate messages.
+      await existing
+      return
+    }
+
+    const confirmation = this.review(delta)
+    this.pending.set(delta, confirmation)
+    let approved: boolean
+    try {
+      approved = await confirmation
+    } finally {
+      this.pending.delete(delta)
+    }
+    if (!approved || this.api.signal.aborted) return
+
+    // MessagePaneInput and InputContainer can both participate in one send.
+    // Let the next wrapper recognize the already-approved Delta.
+    this.approved.add(delta)
+    return send(options)
+  }
+
+  private async review(delta: Delta): Promise<boolean> {
+    try {
+      const [dictionary, blocks] = await Promise.all([
+        this.dictionary,
+        this.api.blocks.fromDelta(delta),
+      ])
+      if (!dictionary || this.api.signal.aborted) return true
+
+      const text = blocksToSlackText(blocks)
+      // This is the same precondition as Orpheus's message checklist. Ruby's
+      // String#length counts Unicode code points rather than UTF-16 units.
+      if ([...text].length >= 300) return true
+
+      const haiku = findHaiku(text, (word) =>
+        dictionaryLookup(dictionary, word)
+      )
+      if (!haiku) return true
+
+      return this.api.modal.confirm({
+        title: (
+          <this.api.elements.MrkdwnElement text=":orpheus-woah: found a haiku in your messsage!" />
+        ),
+        confirmText: 'Send anyway',
+        cancelText: 'Keep editing',
+        body: (
+          <div>
+            <p style={{ marginTop: 0 }}>
+              If Orpheus is in this channel, then she will repeat your message,
+              preserving it so it can&apos;t be deleted. Ensure you&apos;re okay
+              with this message:
+            </p>
+            <blockquote style={{ whiteSpace: 'pre-line', marginBottom: 0 }}>
+              {haiku.join('\n')}
+            </blockquote>
+          </div>
+        ),
+      })
+    } catch (error) {
+      this.log('Could not check message', error)
+      return true
+    }
+  }
+
+  private async loadDictionary(): Promise<string | null> {
+    const cached = await this.api.storage.get<string | null>(
+      DICTIONARY_KEY,
+      null
+    )
+    if (cached) return cached
+
+    try {
+      const response = await this.api.fetch(DICTIONARY_URL, {
+        signal: this.api.signal,
+      })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const dictionary = await response.text()
+      if (dictionary.length < 1_000_000)
+        throw new Error('Incomplete dictionary')
+      if (!this.api.signal.aborted) {
+        await this.api.storage.set(DICTIONARY_KEY, dictionary)
+      }
+      return dictionary
+    } catch (error) {
+      if (!this.api.signal.aborted) this.log('Could not load dictionary', error)
+      return null
+    }
+  }
+}

--- a/plugins/lib/haiku.test.ts
+++ b/plugins/lib/haiku.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  blocksToSlackText,
+  dictionaryLookup,
+  findHaiku,
+  humanizeInteger,
+} from './haiku'
+
+describe('Orpheus haiku matching', () => {
+  const counts: Record<string, number> = {
+    a: 1,
+    again: 2,
+    an: 1,
+    frog: 1,
+    into: 2,
+    jumps: 1,
+    old: 1,
+    pond: 1,
+    silence: 2,
+    silent: 2,
+    splash: 1,
+    the: 1,
+    x: 4,
+    y: 2,
+    z: 1,
+  }
+  const lookup = (word: string) => counts[word]
+
+  test('splits a hidden haiku only at exact 5/7/5 boundaries', () => {
+    expect(
+      findHaiku(
+        'An old silent pond, a frog jumps into the pond — splash, silence again.',
+        lookup
+      )
+    ).toEqual([
+      'an old silent pond',
+      'a frog jumps into the pond',
+      'splash silence again.',
+    ])
+
+    expect(findHaiku('x y z z z z z z z z z z z', lookup)).toBeNull()
+  })
+
+  test('matches humanize 3.1.0 number wording', () => {
+    expect(humanizeInteger('0')).toBe('zero')
+    expect(humanizeInteger('1001')).toBe('one thousand and one')
+    expect(humanizeInteger('1100')).toBe('one thousand, one hundred')
+    expect(humanizeInteger('12345')).toBe(
+      'twelve thousand, three hundred and forty-five'
+    )
+  })
+})
+
+test('dictionary lookup handles boundaries without building a Map', () => {
+  const dictionary = 'alpha 2\nbeta 1\nomega 3\n'
+  expect(dictionaryLookup(dictionary, 'alpha')).toBe(2)
+  expect(dictionaryLookup(dictionary, 'beta')).toBe(1)
+  expect(dictionaryLookup(dictionary, 'omega')).toBe(3)
+  expect(dictionaryLookup(dictionary, 'missing')).toBeUndefined()
+})
+
+test('rich text is reconstructed like a Slack message event', () => {
+  expect(
+    blocksToSlackText([
+      {
+        type: 'rich_text',
+        elements: [
+          {
+            type: 'rich_text_section',
+            elements: [
+              { type: 'text', text: 'hello ' },
+              { type: 'user', user_id: 'U123' },
+              { type: 'text', text: ' in ' },
+              { type: 'channel', channel_id: 'C456' },
+              { type: 'text', text: ' ' },
+              { type: 'link', url: 'https://example.com', text: 'example' },
+              { type: 'text', text: ' ' },
+              { type: 'emoji', name: 'wave' },
+            ],
+          },
+        ],
+      },
+    ])
+  ).toBe('hello <@U123> in <#C456> <https://example.com|example> :wave:')
+})

--- a/plugins/lib/haiku.ts
+++ b/plugins/lib/haiku.ts
@@ -1,0 +1,401 @@
+export type SyllableLookup = (word: string) => number | undefined
+
+const SUB_SYLLABLES = [
+  'cial',
+  'tia',
+  'cius',
+  'cious',
+  'uiet',
+  'gious',
+  'geous',
+  'priest',
+  'giu',
+  'dge',
+  'ion',
+  'iou',
+  'sia$',
+  '.che$',
+  '.ched$',
+  '.abe$',
+  '.ace$',
+  '.ade$',
+  '.age$',
+  '.aged$',
+  '.ake$',
+  '.ale$',
+  '.aled$',
+  '.ales$',
+  '.ane$',
+  '.ame$',
+  '.ape$',
+  '.are$',
+  '.ase$',
+  '.ashed$',
+  '.asque$',
+  '.ate$',
+  '.ave$',
+  '.azed$',
+  '.awe$',
+  '.aze$',
+  '.aped$',
+  '.athe$',
+  '.athes$',
+  '.ece$',
+  '.ese$',
+  '.esque$',
+  '.esques$',
+  '.eze$',
+  '.gue$',
+  '.ibe$',
+  '.ice$',
+  '.ide$',
+  '.ife$',
+  '.ike$',
+  '.ile$',
+  '.ime$',
+  '.ine$',
+  '.ipe$',
+  '.iped$',
+  '.ire$',
+  '.ise$',
+  '.ished$',
+  '.ite$',
+  '.ive$',
+  '.ize$',
+  '.obe$',
+  '.ode$',
+  '.oke$',
+  '.ole$',
+  '.ome$',
+  '.one$',
+  '.ope$',
+  '.oque$',
+  '.ore$',
+  '.ose$',
+  '.osque$',
+  '.osques$',
+  '.ote$',
+  '.ove$',
+  '.pped$',
+  '.sse$',
+  '.ssed$',
+  '.ste$',
+  '.ube$',
+  '.uce$',
+  '.ude$',
+  '.uge$',
+  '.uke$',
+  '.ule$',
+  '.ules$',
+  '.uled$',
+  '.ume$',
+  '.une$',
+  '.upe$',
+  '.ure$',
+  '.use$',
+  '.ushed$',
+  '.ute$',
+  '.ved$',
+  '.we$',
+  '.wes$',
+  '.wed$',
+  '.yse$',
+  '.yze$',
+  '.rse$',
+  '.red$',
+  '.rce$',
+  '.rde$',
+  '.ily$',
+  '.ely$',
+  '.des$',
+  '.gged$',
+  '.kes$',
+  '.ced$',
+  '.ked$',
+  '.med$',
+  '.mes$',
+  '.ned$',
+  '.[sz]ed$',
+  '.nce$',
+  '.rles$',
+  '.nes$',
+  '.pes$',
+  '.tes$',
+  '.res$',
+  '.ves$',
+  'ere$',
+].map((pattern) => new RegExp(pattern))
+
+const ADD_SYLLABLES = [
+  'ia',
+  'riet',
+  'dien',
+  'ien',
+  'iet',
+  'iu',
+  'iest',
+  'io',
+  'ii',
+  'ily',
+  '.oala$',
+  '.iara$',
+  '.ying$',
+  '.earest',
+  '.arer',
+  '.aress',
+  '.eate$',
+  '.eation$',
+  '[aeiouym]bl$',
+  '[aeiou]{3}',
+  '^mc',
+  'ism',
+  '^mc',
+  'asm',
+  '([^aeiouy])1l$',
+  '[^l]lien',
+  '^coa[dglx].',
+  '[^gq]ua[^auieo]',
+  'dnt$',
+].map((pattern) => new RegExp(pattern))
+
+const SMALL = [
+  'zero',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+  'sixteen',
+  'seventeen',
+  'eighteen',
+  'nineteen',
+] as const
+
+const TENS = [
+  '',
+  '',
+  'twenty',
+  'thirty',
+  'forty',
+  'fifty',
+  'sixty',
+  'seventy',
+  'eighty',
+  'ninety',
+] as const
+
+const LOTS = [
+  '',
+  'thousand',
+  'million',
+  'billion',
+  'trillion',
+  'quadrillion',
+  'quintillion',
+  'sextillion',
+  'septillion',
+  'octillion',
+  'nonillion',
+  'decillion',
+  'undecillion',
+  'duodecillion',
+  'tredecillion',
+  'quattuordecillion',
+  'quindecillion',
+  'sexdecillion',
+  'septendecillion',
+  'octodecillion',
+  'novemdecillion',
+  'vigintillion',
+  'unvigintillion',
+  'duovigintillion',
+  'trevigintillion',
+  'quattuortillion',
+  'quinvigintillion',
+  'sexvigintillion',
+  'septenvigintillion',
+  'octovigintillion',
+  'novemvigintillion',
+  'trigintillion',
+  'untrigintillion',
+  'duotrigintillion',
+  'trestrigintillion',
+  'quattuortrigintillion',
+  'quintrigintillion',
+  'sextrigintillion',
+  'septentrigintillion',
+  'octotrigintillion',
+  'novemtrigintillion',
+  'quadragintillion',
+  'unquadragintillion',
+  'duoquadragintillion',
+  'trequadragintillion',
+  'quattuorquadragintillion',
+  'quinquadragintillion',
+  'sesquadragintillion',
+  'septenquadragintillion',
+  'octoquadragintillion',
+  'novenquadragintillion',
+  'quinquagintillion',
+] as const
+
+function underThousand(value: number): string {
+  if (value < 20) return SMALL[value]
+  if (value < 100) {
+    const remainder = value % 10
+    return `${TENS[Math.floor(value / 10)]}${remainder ? `-${SMALL[remainder]}` : ''}`
+  }
+  const remainder = value % 100
+  return `${SMALL[Math.floor(value / 100)]} hundred${remainder ? ` and ${underThousand(remainder)}` : ''}`
+}
+
+/** Matches Integer#humanize from humanize 3.1.0, which Orpheus uses. */
+export function humanizeInteger(digits: string): string {
+  let value = BigInt(digits)
+  if (value === 0n) return 'zero'
+
+  let iteration = 0
+  let useAnd = false
+  const parts: string[] = []
+  while (value !== 0n) {
+    const remainder = Number(value % 1000n)
+    value /= 1000n
+    if (remainder !== 0) {
+      if (iteration === 0 && remainder < 100) useAnd = true
+      else if (LOTS[iteration]) {
+        parts.push(
+          `${LOTS[iteration]}${parts.length ? (useAnd ? ' and' : ',') : ''}`
+        )
+      }
+      parts.push(underThousand(remainder))
+    }
+    iteration++
+  }
+  return parts.reverse().join(' ')
+}
+
+export function estimateSyllables(word: string): number {
+  if (!word) return 0
+  word = word.toLowerCase()
+  let syllables = word.split(/[^aeiouy]+/).filter(Boolean).length
+  for (const pattern of SUB_SYLLABLES) {
+    if (pattern.test(word)) syllables--
+  }
+  for (const pattern of ADD_SYLLABLES) {
+    if (pattern.test(word)) syllables++
+  }
+  return Math.max(1, syllables)
+}
+
+/**
+ * Tests the same normalized text and 5/7/5 word boundaries as Orpheus.
+ * The caller supplies Orpheus's pronunciation-table lookup.
+ */
+export function findHaiku(
+  input: string,
+  lookup: SyllableLookup
+): [string, string, string] | null {
+  // Ruby's `\s` is ASCII-only; JavaScript's also includes Unicode spaces.
+  let text = input.toLowerCase().replace(/[^a-zA-Z0-9 \t\n\v\f\r.$]/g, '')
+  text = text.replace(/\$/g, 'dollar ').replace(/\bise\b/g, 'ize')
+  text = text.replace(/\d+/g, humanizeInteger)
+
+  const lines: string[][] = [[], [], []]
+  const targets = [5, 7, 5]
+  let line = 0
+  let count = 0
+  for (const word of text.split(/[ \t\n\v\f\r]+/).filter(Boolean)) {
+    const syllables = lookup(word) ?? estimateSyllables(word)
+    if (line > 2 || count + syllables > targets[line]) return null
+    lines[line].push(word)
+    count += syllables
+    if (count === targets[line]) {
+      line++
+      count = 0
+    }
+  }
+
+  return line === 3
+    ? [lines[0].join(' '), lines[1].join(' '), lines[2].join(' ')]
+    : null
+}
+
+/** Looks up one word without allocating a 134k-entry Map. Input must be sorted. */
+export function dictionaryLookup(
+  dictionary: string,
+  word: string
+): number | undefined {
+  let low = 0
+  let high = dictionary.length
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2)
+    const lineStart =
+      middle === 0 ? 0 : dictionary.lastIndexOf('\n', middle - 1) + 1
+    let lineEnd = dictionary.indexOf('\n', lineStart)
+    if (lineEnd === -1) lineEnd = dictionary.length
+    const separator = dictionary.lastIndexOf(' ', lineEnd - 1)
+    const candidate = dictionary.slice(lineStart, separator)
+    if (candidate === word)
+      return Number(dictionary.slice(separator + 1, lineEnd))
+    if (candidate < word) low = lineEnd + 1
+    else high = lineStart
+  }
+  return undefined
+}
+
+type RichTextNode = {
+  type?: string
+  text?: string
+  url?: string
+  user_id?: string
+  channel_id?: string
+  usergroup_id?: string
+  name?: string
+  range?: string
+  timestamp?: number
+  format?: string
+  fallback?: string
+  elements?: RichTextNode[]
+}
+
+function nodeText(node: RichTextNode): string {
+  switch (node.type) {
+    case 'text':
+      return node.text ?? ''
+    case 'link':
+      return node.text ? `<${node.url}|${node.text}>` : `<${node.url}>`
+    case 'user':
+      return `<@${node.user_id}>`
+    case 'channel':
+      return `<#${node.channel_id}>`
+    case 'usergroup':
+      return `<!subteam^${node.usergroup_id}>`
+    case 'broadcast':
+      return `<!${node.range}>`
+    case 'emoji':
+      return `:${node.name}:`
+    case 'date':
+      return `<!date^${node.timestamp}^${node.format}|${node.fallback}>`
+  }
+
+  const separator =
+    node.type === 'rich_text_list' || node.type === 'rich_text_quote'
+      ? '\n'
+      : ''
+  return (node.elements ?? []).map(nodeText).join(separator)
+}
+
+/** Recreates the mrkdwn-like text delivered with Slack message events. */
+export function blocksToSlackText(blocks: unknown[]): string {
+  return (blocks as RichTextNode[]).map(nodeText).join('\n')
+}


### PR DESCRIPTION
## Summary
- add a composer send-time warning before Orpheus can preserve an accidental haiku
- match Orpheus's normalization, number humanization, 5/7/5 boundaries, and pronunciation dictionary without scanning while typing
- reconstruct Slack event text from rich-text blocks and cache the pinned Orpheus dictionary

## Verification
- `bun test plugins/lib/haiku.test.ts`
- `bun run check`
- `bun run build:user-plugin plugins/HaikuWarning.tsx /tmp/HaikuWarning.js`